### PR TITLE
Use lowercase value for display browser

### DIFF
--- a/index.html
+++ b/index.html
@@ -233,7 +233,7 @@
                     Minimal UI
                   </label></div>
                   <div class="radio"><label>
-                    <input type="radio" name="display" value="Browser" />
+                    <input type="radio" name="display" value="browser" />
                     Browser
                   </label></div>
                 </div>


### PR DESCRIPTION
This tool currently generates a display value when using the "Browser" option that is uppercase, e.g.

```json
"display": "Browser",
```

which is invalid, according to the spec. Instead it should use the lowercase "browser", e.g.

```json
"display": "browser",
```

More info: https://github.com/manifoldjs/ManifoldJS/issues/275

Fixes #9